### PR TITLE
ci(pages): only trigger on push to main

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-      - master
-      - claude/modernize-analytics-platform-ai0FR
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The modernization feature branch (`claude/modernize-analytics-platform-ai0FR`) was merged. Drop it from `pages.yml` triggers along with the legacy `master` alias — `main` is the only branch the deploy should fire from now.

## Diff

```yaml
 on:
   push:
     branches:
       - main
-      - master
-      - claude/modernize-analytics-platform-ai0FR
   workflow_dispatch:
```

No behavioral change for `main`; just stops the workflow from being eligible to run on stale branches.

---
_Generated by [Claude Code](https://claude.ai/code/session_012gkmu3wcUb4948yiHWK9Yn)_